### PR TITLE
Add a direct link to Discussions tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Homebrew/discussions
 
 Public open-ended discussions. Possible replacement for our [Discourse](https://discourse.brew.sh).
+
+[:left_speech_bubble: View Discussions](https://github.com/Homebrew/discussions/discussions)


### PR DESCRIPTION
Since Discussions is a new feature, it's not immediately obvious that it occurs on a new tab. 🍺 